### PR TITLE
ruff rules update

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,4 +1,4 @@
 select = ["ALL"]
-ignore = ["ANN101", "ANN102", "D203", "D211", "D212", "D213", "UP009", "S101", "S314", "INP001", "FLY002", "TD002", "TD003", "DTZ007"]
+ignore = ["ANN101", "ANN102", "D203", "D211", "D212", "D213", "UP009", "S101", "S314", "INP001", "FLY002", "TD002", "TD003", "DTZ007", "FA102", "PERF203", "FIX002"]
 
 exclude = ["docs"]

--- a/invenio_campusonline/utils.py
+++ b/invenio_campusonline/utils.py
@@ -136,7 +136,7 @@ def get_metadata(
     root = fromstring(response.text)
 
     xpath = "{http://www.campusonline.at/thesisservice/basetypes}thesis"
-    return list(root.iter(xpath))[0]  # TODO: fix it
+    return list(root.iter(xpath))[0]  # noqa: RUF015
 
 
 def get_file_url(
@@ -151,7 +151,7 @@ def get_file_url(
 
     root = fromstring(response.text)
     xpath = "{http://www.campusonline.at/thesisservice/basetypes}docUrl"
-    file_url = list(root.iter(xpath))[0]  # TODO: make it more nice
+    file_url = list(root.iter(xpath))[0]  # noqa: RUF015
     return file_url.text
 
 


### PR DESCRIPTION
* PERF203: yes the performance could be better, but the moving the try
  except block outside of the loop would change the behaviour in those
  cases

* FA102: is not necessary, we are using only python >=3.9

* RUF015: yes next() would be better performance-wise, but it reads
  strang. if there was a first() it would be selected.
